### PR TITLE
Feat: 명함보기 페이지 내 circle 아이콘이 안보이는 문제 해결

### DIFF
--- a/src/assets/icon.svg
+++ b/src/assets/icon.svg
@@ -178,7 +178,7 @@
 
   <symbol id="circle-check"  viewBox="0 0 16 16" fill="none">
     <circle cx="8" cy="8" r="8" fill="white"/>
-    <path d="M4.30395 8.7971L7.33377 12.5213L11.888 5.66575" stroke="#2D29FF" stroke-linecap="round" stroke-linejoin="round"/>  </symbol>
+    <path d="M4.30395 8.7971L7.33377 12.5213L11.888 5.66575" stroke="#2D29FF" stroke-linecap="round" stroke-linejoin="round"/>
   </symbol>
   
   <symbol id="circle" width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/src/components/CardInfo/CardInfo.jsx
+++ b/src/components/CardInfo/CardInfo.jsx
@@ -39,7 +39,6 @@ export default function CardInfo({
                 : 'circle'
               : 'arrow-right'
           }
-          fill='none'
         />
       </S.ArrowIconWrapper>
     </S.Card>


### PR DESCRIPTION
## 📝 작업 내용

- 명함보기 페이지 내 circle 아이콘이 안보이는 문제 해결

<br />

## 📸 스크린샷

<img width="250" alt="" src="https://github.com/user-attachments/assets/78c63041-bca3-4c31-bae8-c8089ab9117f">
