### PR TITLE
Feat: 명함 상세보기 페이지 정보 구현

### DIFF
--- a/src/pages/CardDetailPage/CardDetailPage.jsx
+++ b/src/pages/CardDetailPage/CardDetailPage.jsx
@@ -1,115 +1,122 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import * as S from './CardDetailPage.style';
 import Icon from '../../components/Icon/Icon';
-import { TabBar } from '../../components';
+import { TabBar, BlueBadge } from '../../components';
 import sampleData from '../../constants/cardData';
 import ProfileImgDefault from '../../assets/images/profile-img-default.svg';
 
-export default function CardDetailPage({
-  name,
-  job,
-  company,
-  phone,
-  email,
-  tel,
-  address,
-  imageUrl,
-}) {
+export default function CardDetailPage() {
+  const { id } = useParams();
+  const [activeBadge, setActiveBadge] = useState(null);
+  const [filteredBadges, setFilteredBadges] = useState([]);
+  const filteredData = sampleData.filter(
+    (data) => data.name === decodeURIComponent(id)
+  );
+
+  useEffect(() => {
+    if (filteredData.length > 0) {
+      const category = filteredData[0].category;
+      const relevantBadges = badges.filter((badge) => badge.value === category);
+      setFilteredBadges(relevantBadges);
+    }
+  }, [filteredData]);
+
+  const badges = [
+    { label: '비즈니스', value: '비즈니스' },
+    { label: '방송사', value: '방송사' },
+    { label: '부동산', value: '부동산' },
+    { label: '대학교', value: '대학교' },
+  ];
+
   return (
     <>
-      <S.TopContainer>
-        <S.TopBar>
-          <S.LeftContainer1 />
-          <S.MyName>
-            <Icon id='logo-white' width='60' height='24.5' />
-          </S.MyName>
-          <S.EditIcon>편집하기</S.EditIcon>
-        </S.TopBar>
-        <S.MidBar>
-          <S.LeftContainer2 />
-          <S.PicContainer>
-            <S.ProfilePic
-              src={imageUrl || ProfileImgDefault}
-              alt={`${name} 프로필`}
-            />
-          </S.PicContainer>
-          <S.IconBarContainer>
-            <Icon id='gallery' fill='#FFFFFF' width='18' height='18' />
-            <S.Dot3Icon>
-              <Icon
-                id='dot3'
-                className='dot3-icon'
-                fill='#FFFFFF'
-                width='5'
-                height='20'
+      {filteredData.map((data, index) => (
+        <React.Fragment key={index}>
+          <S.TopContainer>
+            <S.TopBar>
+              <S.LeftContainer1 />
+              <S.MyName>
+                <Icon id='logo-white' width='60' height='24.5' />
+              </S.MyName>
+              <S.EditIcon>편집하기</S.EditIcon>
+            </S.TopBar>
+            <S.MidBar>
+              <S.LeftContainer2 />
+              <S.PicContainer>
+                <S.ProfilePic
+                  src={data.imageUrl || ProfileImgDefault}
+                  alt={`${data.name} 프로필`}
+                />
+              </S.PicContainer>
+              <S.IconBarContainer>
+                <Icon id='gallery' fill='#FFFFFF' width='18' height='18' />
+                <S.Dot3Icon>
+                  <Icon
+                    id='dot3'
+                    className='dot3-icon'
+                    fill='#FFFFFF'
+                    width='5'
+                    height='20'
+                  />
+                </S.Dot3Icon>
+              </S.IconBarContainer>
+            </S.MidBar>
+            <S.BotBar>
+              <S.NameBox>
+                <S.NameFont>{data.name}</S.NameFont>
+                <S.JobTeamFont>{data.job}</S.JobTeamFont>
+                <S.ComFont>{data.company}</S.ComFont>
+              </S.NameBox>
+              <S.SubBar />
+            </S.BotBar>
+          </S.TopContainer>
+
+          <S.BottomContainer>
+            <S.ConBar>연락처</S.ConBar>
+            <S.ContactContainer>
+              <S.InfoBox>
+                <S.UserInfoLabel>휴대폰</S.UserInfoLabel>
+                <S.ContactWrapper>
+                  <S.UserInfoValue>{data.phone}</S.UserInfoValue>
+                  <S.IconBox>
+                    <Icon id='message' width='20' height='14' />
+                    <Icon id='call' width='20' height='14' />
+                  </S.IconBox>
+                </S.ContactWrapper>
+              </S.InfoBox>
+              <S.InfoBox>
+                <S.UserInfoLabel>이메일</S.UserInfoLabel>
+                <S.ContactWrapper>
+                  <S.UserInfoValue>{data.email}</S.UserInfoValue>
+                  <Icon id='mail' width='20' height='14' />
+                </S.ContactWrapper>
+              </S.InfoBox>
+              <S.InfoBox>
+                <S.UserInfoLabel>유선전화</S.UserInfoLabel>
+                <S.ContactWrapper>
+                  <S.UserInfoValue>{data.tel}</S.UserInfoValue>
+                  <Icon id='call' width='20' height='14' />
+                </S.ContactWrapper>
+              </S.InfoBox>
+              <S.InfoBox>
+                <S.UserInfoLabel>주소</S.UserInfoLabel>
+                <S.UserInfoValue>{data.address}</S.UserInfoValue>
+              </S.InfoBox>
+            </S.ContactContainer>
+            <S.GroupButtonBar>그룹</S.GroupButtonBar>
+            <S.GroupButtonBox>
+              <BlueBadge
+                badges={filteredBadges}
+                activeBadge={activeBadge}
+                setActiveBadge={setActiveBadge}
+                fill='#2d29ff'
               />
-            </S.Dot3Icon>
-          </S.IconBarContainer>
-        </S.MidBar>
-        <S.BotBar>
-          <S.NameBox>
-            <S.NameFont>{name}</S.NameFont>
-            <S.JobTeamFont>{job}</S.JobTeamFont>
-            <S.ComFont>{company}</S.ComFont>
-          </S.NameBox>
-          <S.SubBar />
-        </S.BotBar>
-      </S.TopContainer>
-
-      <S.BottomContainer>
-        <S.ConBar>연락처</S.ConBar>
-        <S.ContactContainer>
-          <S.InfoBox>
-            <S.userInfoLabel>휴대폰</S.userInfoLabel>
-            <S.ContactWrapper>
-              <S.userInfoValue>{phone}</S.userInfoValue>
-
-              <S.IconBox>
-                <Icon id='message' width='20' height='14' />
-                <Icon id='call' width='20' height='14' />
-              </S.IconBox>
-            </S.ContactWrapper>
-          </S.InfoBox>
-          <S.InfoBox>
-            <S.userInfoLabel>이메일</S.userInfoLabel>
-            <S.ContactWrapper>
-              <S.userInfoValue>{email}</S.userInfoValue>
-              <Icon id='mail' width='20' height='14' />
-            </S.ContactWrapper>
-          </S.InfoBox>
-          <S.InfoBox>
-            <S.userInfoLabel>유선전화</S.userInfoLabel>
-            <S.ContactWrapper>
-              <S.userInfoValue>{tel}</S.userInfoValue>
-              <Icon id='call' width='20' height='14' />
-            </S.ContactWrapper>
-          </S.InfoBox>
-          <S.InfoBox>
-            <S.userInfoLabel>주소</S.userInfoLabel>
-            <S.userInfoValue>{address}</S.userInfoValue>
-          </S.InfoBox>
-        </S.ContactContainer>
-        <S.GroupButtonBar>그룹</S.GroupButtonBar>
-        <S.GroupButtonBox></S.GroupButtonBox>
-      </S.BottomContainer>
+            </S.GroupButtonBox>
+          </S.BottomContainer>
+        </React.Fragment>
+      ))}
       <TabBar />
     </>
   );
 }
-
-CardDetailPage.propTypes = {
-  name: PropTypes.string.isRequired,
-  job: PropTypes.string.isRequired,
-  company: PropTypes.string.isRequired,
-  phone: PropTypes.string.isRequired,
-  email: PropTypes.string.isRequired,
-  tel: PropTypes.string.isRequired,
-  address: PropTypes.string.isRequired,
-  imageUrl: PropTypes.string,
-};
-
-CardDetailPage.defaultProps = {
-  imageUrl: ProfileImgDefault,
-};

--- a/src/pages/CardDetailPage/CardDetailPage.style.jsx
+++ b/src/pages/CardDetailPage/CardDetailPage.style.jsx
@@ -173,7 +173,7 @@ export const GroupButtonBox = styled.div`
 `;
 
 //폰트
-export const userInfoLabel = styled.div`
+export const UserInfoLabel = styled.div`
   color: var(--grey2, #949494);
   font-size: 11px;
   font-weight: 400;
@@ -181,7 +181,7 @@ export const userInfoLabel = styled.div`
   letter-spacing: -0.5px;
 `;
 
-export const userInfoValue = styled.div`
+export const UserInfoValue = styled.div`
   color: var(--grey4, #1a1a1a);
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
## 📝 작업 내용

-명함 상세보기 페이지에 정보 포함해서 다시 구현하였습니다
-그룹 컴포넌트 추가하였습니다
-뱃지는 색상이 #2d29ff로 나와야하는데.... 방법을 잘 모르겠어요..
-홍길동이 두명이라 페이지도 두개가 뜨는 이슈가 있습니다.. 필터링은 다시 생각해보겠습니다

<br />

## 📸 스크린샷

<img width="250" alt="" src="https://github.com/user-attachments/assets/a773c162-ae40-4780-925a-1fe7b871aa63">

<br />

<!--
## 📌 참고사항

<br />
-->
