### PR TITLE
Fix: 로고 컬러는 props로 전달하지 않아서 생기는 오류 해결

### DIFF
--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -54,7 +54,7 @@ export default function ViewCardPage() {
   return (
     <>
       <S.ViewCardPage>
-        <Header />
+        <Header color='blue' />
         <SearchBar theme='white' />
 
         {/* 그룹 설정 버튼 */}


### PR DESCRIPTION
## 📝 작업 내용

- 로고 컬러는 props로 전달하지 않아서 생기는 오류 해결

<br />

## ✅ PR 전 체크리스트

- [x] `시멘틱 태그`, `명확한 함수명과 컴포넌트명`을 사용하였나요?
- [x] 작업한 내용을 리뷰어가 쉽게 이해할 수 있도록 상세히 작성하였나요?
- [x] 로컬 환경에서 구현한 화면이 오류 없이 동작하는지 확인했나요?
- [x] 이번 PR에서 `구현되지 않은 부분`, `예정된 기능 개선` 등은 `참고사항`에 명시했나요?
- [x] PR 완료 후 `충돌(conflict)` 여부를 확인하고, 충돌이 있다면 해결해 주세요.

<br />

## 📸 스크린샷
|오류 해결 완료|
|:-----:|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/069ddf63-4b59-447a-b270-3d691f0e092c">|

<br />

## 📌 참고사항
- 현재 남아 있는 오류는 a태그가 중첩되어 생긴 오류(`<a>태그`를 `<a>태그`가 감쌌음)로, #63에서 해결 완료 했습니다 (#63이 merge되면 사라질 오류)

<br />
