### PR TITLE
Feat: 그룹수정 모달 띄우기 구현

### DIFF
--- a/src/components/AddGroupModal/AddGroupModal.style.jsx
+++ b/src/components/AddGroupModal/AddGroupModal.style.jsx
@@ -17,9 +17,8 @@ export const Container = styled.div`
   padding-bottom: 70px;
   width: 100%;
   max-width: 768px;
-  left: 50%;
-  transform: translateX(-50%)
-    ${({ isModalOpen }) => (isModalOpen ? 'translateY(0)' : 'translateY(100%)')};
+  transform: ${({ isModalOpen }) =>
+    isModalOpen ? 'translateY(0)' : 'translateY(100%)'};
   opacity: ${({ isModalOpen }) => (isModalOpen ? 1 : 0)};
   transition:
     transform 400ms cubic-bezier(0.86, 0, 0.07, 1),

--- a/src/components/AddGroupModal/AddGroupModal.style.jsx
+++ b/src/components/AddGroupModal/AddGroupModal.style.jsx
@@ -17,8 +17,9 @@ export const Container = styled.div`
   padding-bottom: 70px;
   width: 100%;
   max-width: 768px;
-  transform: ${({ isModalOpen }) =>
-    isModalOpen ? 'translateY(0)' : 'translateY(100%)'};
+  left: 50%;
+  transform: translateX(-50%)
+    ${({ isModalOpen }) => (isModalOpen ? 'translateY(0)' : 'translateY(100%)')};
   opacity: ${({ isModalOpen }) => (isModalOpen ? 1 : 0)};
   transition:
     transform 400ms cubic-bezier(0.86, 0, 0.07, 1),

--- a/src/pages/DetailEditPage/DetailEditPage.jsx
+++ b/src/pages/DetailEditPage/DetailEditPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, memo } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import * as S from './DetailEditPage.style';
 import Icon from '../../components/Icon/Icon';
-import { BlueBadge } from '../../components';
+import { BlueBadge, AddGroupModal } from '../../components';
 import CARDS_SAMPLE_DATA from '../../constants/cardsSampleData';
 import ProfileImgDefault from '../../assets/images/profile-img-default.svg';
 
@@ -226,6 +226,16 @@ export default function DetailEditPage() {
 
   const profileImageUrl = data.imageUrl || ProfileImgDefault;
 
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const openModal = () => {
+    setModalVisible(true);
+  };
+
+  const handleClose = () => {
+    setModalVisible(false);
+  };
+
   return (
     <>
       <S.DetailEdit>
@@ -321,12 +331,16 @@ export default function DetailEditPage() {
               setActiveBadge={setActiveBadge}
               fill='#2d29ff'
             />
-            <S.PlusBtnWrapper>
-              <S.PlusText>그룹 추가</S.PlusText>
+            <S.PlusBtnWrapper onClick={openModal}>
+              <S.PlusText>그룹 수정</S.PlusText>
               <S.MoreIcon>
                 <Icon id='more' fill='#2D29FF' />
               </S.MoreIcon>
             </S.PlusBtnWrapper>
+            <AddGroupModal
+              isModalOpen={modalVisible}
+              setIsModalOpen={setModalVisible}
+            />
           </S.GroupButtonBox>
         </S.GroupButtonContainer>
       </S.DetailEdit>

--- a/src/pages/DetailEditPage/DetailEditPage.jsx
+++ b/src/pages/DetailEditPage/DetailEditPage.jsx
@@ -232,10 +232,6 @@ export default function DetailEditPage() {
     setModalVisible(true);
   };
 
-  const handleClose = () => {
-    setModalVisible(false);
-  };
-
   return (
     <>
       <S.DetailEdit>
@@ -337,13 +333,13 @@ export default function DetailEditPage() {
                 <Icon id='more' fill='#2D29FF' />
               </S.MoreIcon>
             </S.PlusBtnWrapper>
-            <AddGroupModal
-              isModalOpen={modalVisible}
-              setIsModalOpen={setModalVisible}
-            />
           </S.GroupButtonBox>
         </S.GroupButtonContainer>
       </S.DetailEdit>
+      <AddGroupModal
+        isModalOpen={modalVisible}
+        setIsModalOpen={setModalVisible}
+      />
     </>
   );
 }


### PR DESCRIPTION
## 📝 작업 내용

- 명함 수정페이지에서 그룹수정 모달 띄우기 구현
- 모달 컴포넌트를 정중앙 배치하는 것으로 모달 css 수정

<br />

## ✅ PR 전 체크리스트

- [x] `시멘틱 태그`, `명확한 함수명과 컴포넌트명`을 사용하였나요?
- [x] 작업한 내용을 리뷰어가 쉽게 이해할 수 있도록 상세히 작성하였나요?
- [x] 로컬 환경에서 구현한 화면이 오류 없이 동작하는지 확인했나요?
- [x] 이번 PR에서 `구현되지 않은 부분`, `예정된 기능 개선` 등은 `참고사항`에 명시했나요?
- [x] PR 완료 후 `충돌(conflict)` 여부를 확인하고, 충돌이 있다면 해결해 주세요.

<br />

## 📸 스크린샷

<img width="250" alt="" src="https://github.com/user-attachments/assets/e8d36aae-eefd-41dc-872e-d860cd759cfa">


<br />


## 📌 참고사항
- 그룹 뱃지 컴포넌트 구현 중
<br />

