### PR TITLE
#91 [FEAT] 그룹 조회/생성/삭제 API 연결

### DIFF
--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -8,7 +8,7 @@ export const getGroupList = async ({ member_id }) => {
 };
 
 // 그룹 생성
-export const postGroup = async ({ name }) => {
+export const postGroup = async ({ member_id, name }) => {
   const data = {
     name: name,
   };
@@ -17,7 +17,7 @@ export const postGroup = async ({ name }) => {
 };
 
 // 그룹 삭제
-export const deleteGroup = async (member_id, category_id) => {
+export const deleteGroup = async ({ member_id, category_id }) => {
   const response = await authAxios.delete(
     `/categories/${member_id}/${category_id}`
   );
@@ -25,7 +25,7 @@ export const deleteGroup = async (member_id, category_id) => {
 };
 
 // 그룹 수정
-export const putGroup = async ({ name }) => {
+export const putGroup = async ({ member_id, name }) => {
   const data = {
     name: name,
   };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,1 +1,1 @@
-export { getGroupList } from './group';
+export { getGroupList, postGroup, deleteGroup, putGroup } from './group';

--- a/src/components/AddGroupModal/AddGroupModal.jsx
+++ b/src/components/AddGroupModal/AddGroupModal.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-// import { useQuery } from 'react-query';
 import { useQuery } from '@tanstack/react-query';
 import * as S from './AddGroupModal.style';
 import { InputWrapper } from '../InputWrapper';
@@ -11,8 +10,10 @@ export default function AddGroupModal({
   isModalOpen,
   setIsModalOpen,
 }) {
-  // 그룹 리스트 가져오기
-  console.log(member_id);
+  const [newBadgeLabel, setNewBadgeLabel] = useState('');
+  const [badges, setBadges] = useState([]);
+  const [showModal, setShowModal] = useState(isModalOpen);
+
   const {
     data: groupListData,
     isLoading,
@@ -21,34 +22,18 @@ export default function AddGroupModal({
     queryKey: ['groupList', member_id],
     queryFn: () => getGroupList({ member_id }),
     enabled: !!member_id,
-    isError: (error) => {
-      console.log(error);
-    },
   });
 
-  const initialBadges = [
-    { label: '비즈니스', value: '비즈니스' },
-    { label: '방송사', value: '방송사' },
-    { label: '부동산', value: '부동산' },
-    { label: '대학교', value: '대학교' },
-  ];
-
-  const [newBadgeLabel, setNewBadgeLabel] = useState('');
-  const [badges, setBadges] = useState([]);
-  const [initialBadgesState, setInitialBadgesState] = useState(initialBadges);
-  const [showModal, setShowModal] = useState(isModalOpen);
-
-  console.log(groupListData);
-
   useEffect(() => {
-    if (isModalOpen) {
-      setShowModal(true);
-      setInitialBadgesState([...badges]);
-    } else {
-      const timeout = setTimeout(() => setShowModal(false), 400);
-      return () => clearTimeout(timeout);
+    if (groupListData) {
+      console.log('groupListData: ', groupListData.data);
+      const initialBadges = groupListData.data.map((group) => ({
+        label: group.id, // or whatever label makes sense
+        value: group.name,
+      }));
+      setBadges(initialBadges); // Set badges to the fetched groups
     }
-  }, [isModalOpen]);
+  }, [groupListData]);
 
   const handleAddBadge = () => {
     const trimmedLabel = newBadgeLabel.trim();
@@ -71,7 +56,6 @@ export default function AddGroupModal({
   };
 
   const handleCancelBtnClick = () => {
-    setBadges([...initialBadgesState]);
     setIsModalOpen(false);
   };
 

--- a/src/components/AddGroupModal/AddGroupModal.jsx
+++ b/src/components/AddGroupModal/AddGroupModal.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import * as S from './AddGroupModal.style';
 import { InputWrapper } from '../InputWrapper';
 import { PrimaryButton, SecondaryButton, BlueBadge } from '../';
-import { getGroupList } from '../../apis';
+import { getGroupList, postGroup, deleteGroup } from '../../apis';
 
 export default function AddGroupModal({
   member_id,
@@ -12,6 +12,7 @@ export default function AddGroupModal({
 }) {
   const [newBadgeLabel, setNewBadgeLabel] = useState('');
   const [badges, setBadges] = useState([]);
+  const [groupListNames, setGroupListNames] = useState([]); // 상태 추가
   const [showModal, setShowModal] = useState(isModalOpen);
 
   const {
@@ -27,11 +28,22 @@ export default function AddGroupModal({
   useEffect(() => {
     if (groupListData) {
       console.log('groupListData: ', groupListData.data);
+
+      // 초기 badges와 groupListNames 배열을 생성
       const initialBadges = groupListData.data.map((group) => ({
-        label: group.id, // or whatever label makes sense
+        label: group.id,
         value: group.name,
       }));
-      setBadges(initialBadges); // Set badges to the fetched groups
+
+      // badges 상태 설정
+      setBadges(initialBadges);
+
+      // groupListNames 배열 생성 및 상태 설정
+      const names = groupListData.data.map((group) => group.name);
+      setGroupListNames(names); // 상태로 저장
+
+      // groupListNames을 로그로 출력
+      console.log('groupListNames: ', names);
     }
   }, [groupListData]);
 
@@ -52,7 +64,30 @@ export default function AddGroupModal({
 
   const handleDoneBtnClick = () => {
     setIsModalOpen(false);
-    console.log(badges);
+
+    // 추가된 badges 찾기
+    const newBadges = badges
+      .filter((badge) => !groupListNames.includes(badge.value)) // badge.value를 사용
+      .map((badge) => badge.value); // badge.name이 아니라 badge.value 사용
+
+    // 각 newBadges에 대해 postGroup 호출
+    newBadges.forEach((badgeName) => {
+      postGroup({ member_id, name: badgeName });
+    });
+
+    // 삭제된 badges의 id값 찾기
+    const deletedBadges = groupListData.data
+      .filter((group) => !badges.some((badge) => badge.value === group.name)) // 현재 badges에 없는 그룹 이름 필터링
+      .map((group) => group.id); // 삭제된 그룹의 ID를 가져옴
+
+    // 각 deletedBadges에 대해 deleteGroup 호출
+    deletedBadges.forEach((category_id) => {
+      deleteGroup({ member_id, category_id });
+    });
+
+    console.log('badges: ', badges);
+    console.log('newBadges: ', newBadges);
+    console.log('deletedBadges: ', deletedBadges);
   };
 
   const handleCancelBtnClick = () => {

--- a/src/components/AddGroupModal/AddGroupModal.style.jsx
+++ b/src/components/AddGroupModal/AddGroupModal.style.jsx
@@ -23,6 +23,9 @@ export const Container = styled.div`
   transition:
     transform 400ms cubic-bezier(0.86, 0, 0.07, 1),
     opacity 400ms cubic-bezier(0.86, 0, 0.07, 1);
+  box-shadow:
+    0px -2px 10px rgba(0, 0, 0, 0.05),
+    0px 2px 10px rgba(0, 0, 0, 0.05);
 `;
 
 export const AddGroupModal = styled.div`

--- a/src/components/Badge/BlueBadge.jsx
+++ b/src/components/Badge/BlueBadge.jsx
@@ -24,7 +24,7 @@ export default function BlueBadge({
               X
             </p>
           )}
-          {badge.label}
+          {badge.value}
         </S.BlueBadge>
       ))}
     </>


### PR DESCRIPTION
## 📝 작업 내용
- 그룹 조회 / 생성 / 삭제 api 연결

<br />

## 📸 스크린샷
https://github.com/user-attachments/assets/b845bcc9-6c68-4d11-a149-5f7c8e1278e8

그룹 조회 / 생성 / 삭제 api 연결


<br />

## 📌 참고사항
- 이전 `feat/#82-group-apis`에서 잘 안 되는 부분이 있어 그룹 관련 API 일부를 여기 브랜치에서 작업함 (다음부터는 브랜치 맞게 작업하겠습니다...🥹)
- 그룹 생성/삭제에 대한 조회 실시간 업데이트는 추후 구현 예정(현재는 새로고침을 해야 바꾼 내용 적용 됨)
- 현재 그룹 조회할 때 member_id를 dummy data인 5로 쓰고 있으니 참고 바람
- 그룹 수정에 대한 로직은 아예 다른 곳에 있어 추후 구현 예정
<br />
