### PR TITLE
#104 [FEAT] CORS 에러 처리 및 임시 토큰 헤더 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -1,9 +1,36 @@
 import axios from 'axios';
 
+const VITE_SERVER_DOMAIN = import.meta.env.VITE_SERVER_DOMAIN;
+
 export const authAxios = axios.create({
-  baseURL: 'http://43.203.244.152:8080',
+  baseURL: VITE_SERVER_DOMAIN,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+const getTokenFromCookie = () => {
+  // const cookie = document.cookie
+  //   .split('; ')
+  //   .find((row) => row.startsWith('token='));
+  // return cookie ? cookie.split('=')[1] : null;
+  return dummyToken;
+};
+
+const dummyToken =
+  '여기에 로그인 링크 타고 들어갔을 때 쿠키에 뜨는 토큰값을 넣어주세요';
+
+// 요청을 보낼 때 Bearer Token을 Authorization 헤더에 추가합니다.
+authAxios.interceptors.request.use(
+  (config) => {
+    const token = getTokenFromCookie();
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   // root: 'src',
   plugins: [react()],
+  server: {
+    port: 8080,
+  },
 });


### PR DESCRIPTION
#104 

## 📝 작업 내용
- CORS 오류 안 나게 백엔드와 조율
- 포트번호 8080으로 고정
- .env 파일 gitignore 설정
- 로그인 구현 전까지는 수동으로 토큰 넣을 수 있도록 구현

<br />

## 📸 스크린샷

| <img width="1115" alt="image" src="https://github.com/user-attachments/assets/f72d07b3-411f-428e-ac25-69857cb529e8"> |
| :-----: | 
| 포트번호 8080으로 고정 |

| <img width="1512" alt="스크린샷 2024-11-26 오전 1 55 07" src="https://github.com/user-attachments/assets/9a37a4eb-0ee5-4d47-b6d1-a01ed483d876"> |
| :-----: | 
| CORS 오류 더 이상 안 뜸(현재 뜨는 오류는 추후 수정) |

<br />

## 📌 참고사항
- .env 파일과 구체적인 토큰 사용 방법에 대해서는 톡방에서 얘기하겠습니다!

<br />

