### PR TITLE
#149 [FEAT] 검색 API 연결

### DIFF
--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getCards, searchCards } from '../../apis';
+import { searchCards } from '../../apis';
 import Icon from '../../components/Icon/Icon';
 import * as S from './SearchBar.style';
 
@@ -29,34 +29,20 @@ export default function SearchBar({
   }, [keyword]);
 
   useEffect(() => {
-    if (debouncedKeyword === '') {
-      fetchCards();
-    } else {
-      fetchSearchCard();
-    }
+    fetchSearchCard();
   }, [debouncedKeyword]);
 
   const fetchSearchCard = async () => {
     try {
-      const response = await searchCards({ keyword: debouncedKeyword });
+      const response = await searchCards({
+        keyword: localStorage.getItem('searchKeyword'),
+      });
       const exceptMyCard = response.data.cards.filter(
         (card) => card.id !== myCardId
       );
       setSearchData(exceptMyCard);
     } catch (error) {
       console.error('검색 요청 실패:', error);
-    }
-  };
-
-  const fetchCards = async () => {
-    try {
-      const response = await getCards();
-      const exceptMyCard = response.data.cards.filter(
-        (card) => card.id !== myCardId
-      );
-      setSearchData(exceptMyCard);
-    } catch (error) {
-      console.error('카드 리스트 불러오기 실패:', error);
     }
   };
 

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { searchCards } from '../../apis';
 import Icon from '../../components/Icon/Icon';
 import * as S from './SearchBar.style';
@@ -9,9 +9,10 @@ export default function SearchBar({
   setSearchData = () => {},
   myCardId,
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [keyword, setKeyword] = useState('');
   const [debouncedKeyword, setDebouncedKeyword] = useState('');
-  const location = useLocation();
 
   useEffect(() => {
     if (location.pathname.startsWith('/card')) {
@@ -33,6 +34,7 @@ export default function SearchBar({
   }, [debouncedKeyword]);
 
   const fetchSearchCard = async () => {
+    if (!myCardId) return;
     try {
       const response = await searchCards({
         keyword: localStorage.getItem('searchKeyword'),
@@ -46,11 +48,13 @@ export default function SearchBar({
     }
   };
 
-  const handleSearch = (event) => {
+  const handleSearch = () => {
     const trimmedValue = keyword.trim();
     if (trimmedValue) {
       localStorage.setItem('searchKeyword', trimmedValue);
-      fetchSearchCard();
+      if (location.pathname === '/home') {
+        navigate('/card');
+      }
     }
   };
 

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -32,8 +32,14 @@ export default function SearchBar({ theme, setSearchData = () => {} }) {
   };
 
   const handleSearch = (event) => {
-    if (event.key === 'Enter' && inputValue.trim()) {
-      navigate(`/card?keyword=${encodeURIComponent(inputValue)}`);
+    if (event.key !== 'Enter') return;
+    const trimmedValue = inputValue.trim();
+    if (trimmedValue || location.pathname !== '/home') {
+      navigate(
+        trimmedValue
+          ? `/card?keyword=${encodeURIComponent(trimmedValue)}`
+          : '/card'
+      );
     }
   };
 

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -10,22 +10,27 @@ export default function HomePage() {
   // const [filterdList, setFilterdList] = useState([]);
   const [myCardData, setMyCardData] = useState([]);
   const [cardsData, setCardsData] = useState([]);
+  const [myCardId, setMyCardId] = useState(null);
   // useVisibleCardsEffect(setFilterdList, cardsData);
 
   async function fetchMyCard() {
     try {
       const response = await getMyCard();
       setMyCardData(response.data);
+      setMyCardId(response.data.id);
     } catch (error) {
       console.error('내 카드 정보를 불러오지 못했습니다.', error);
     }
   }
 
   async function fetchCards() {
+    if (!myCardId) return;
     try {
       const response = await getCards();
-      // const filteredCards = cards.filter((card) => card.id !== myCardData.id);
-      setCardsData(response.data.cards);
+      const exceptMyCard = response.data.cards.filter(
+        (card) => card.id !== myCardId
+      );
+      setCardsData(exceptMyCard);
     } catch (error) {
       console.error('카드 리스트를 불러오지 못했습니다.', error);
     }
@@ -33,8 +38,13 @@ export default function HomePage() {
 
   useEffect(() => {
     fetchMyCard();
-    fetchCards();
   }, []);
+
+  useEffect(() => {
+    if (myCardData) {
+      fetchCards();
+    }
+  }, [myCardData]);
 
   return (
     <S.HomePage>

--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -5,6 +5,9 @@ import Icon from '../../components/Icon/Icon';
 import * as S from './ViewCardPage.style';
 
 export default function ViewCardPage() {
+  const location = useLocation();
+
+  const [searchData, setSearchData] = useState([]);
   const [activeBadge, setActiveBadge] = useState({ id: 0, name: '전체 보기' });
   const [isEditCompleteVisible, setIsEditCompleteVisible] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
@@ -54,6 +57,12 @@ export default function ViewCardPage() {
     fetchGroups();
   }, []);
 
+  let filteredData =
+    activeBadge === '전체 보기'
+      ? cardsData
+      : cardsData.filter((data) => data.categoryName === activeBadge);
+
+  filteredData = filteredData.sort((a, b) => a.name.localeCompare(b.name));
   useEffect(() => {
     fetchCards();
   }, [myCardId, activeBadge]);
@@ -81,11 +90,15 @@ export default function ViewCardPage() {
     }
   };
 
+  const searchParams = new URLSearchParams(location.search);
+  const keyword = searchParams.get('keyword');
+  const displayData = keyword ? searchData : cardsData;
+
   return (
     <>
       <S.ViewCardPage>
         <Header color='blue' />
-        <SearchBar theme='white' />
+        <SearchBar theme='white' setSearchData={setSearchData} />
 
         <S.ButtonContainer>
           <S.GroupBadgeWrapper>
@@ -99,6 +112,7 @@ export default function ViewCardPage() {
             <S.DeleteCardBadge onClick={handleDeleteClick}>
               <S.BadgeText>명함 삭제</S.BadgeText>
               <Icon id='trash' />
+              <Icon id='trash' />
             </S.DeleteCardBadge>
             {isEditCompleteVisible && (
               <S.EditCompletedBadge onClick={handleEditCompleteClick}>
@@ -109,7 +123,7 @@ export default function ViewCardPage() {
         </S.ButtonContainer>
 
         <S.CardContainer>
-          {cardsData.map((data, index) => (
+          {displayData.map((data, index) => (
             <CardInfo
               id={data.id}
               key={index}

--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -1,21 +1,18 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { getCards, getCardsByGroup, getGroupList, getMyCard } from '../../apis';
 import { BlueBadge, CardInfo, Header, SearchBar } from '../../components';
 import Icon from '../../components/Icon/Icon';
 import * as S from './ViewCardPage.style';
 
 export default function ViewCardPage() {
-  const location = useLocation();
-
-  const [searchData, setSearchData] = useState([]);
+  const [myCardId, setMyCardId] = useState(null);
   const [activeBadge, setActiveBadge] = useState({ id: 0, name: '전체 보기' });
   const [isEditCompleteVisible, setIsEditCompleteVisible] = useState(false);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
   const [selectedCards, setSelectedCards] = useState([]);
   const [cardsData, setCardsData] = useState([]);
   const [badges, setBadges] = useState([{ id: 0, name: '전체 보기' }]);
-  const [myCardId, setMyCardId] = useState(null);
+  const [searchData, setSearchData] = useState([]);
 
   async function fetchMyCard() {
     try {
@@ -92,16 +89,15 @@ export default function ViewCardPage() {
     }
   };
 
-  const searchParams = new URLSearchParams(location.search);
-  const keyword = searchParams.get('keyword');
+  const searchKeyword = localStorage.getItem('searchKeyword') || '';
 
   const getDisplayData = () => {
-    if (keyword && activeBadge?.id !== 0) {
+    if (searchKeyword && activeBadge?.id !== 0) {
       return cardsData.filter((card) =>
         searchData.some((searchCard) => searchCard.id === card.id)
       );
     }
-    if (!keyword) {
+    if (!searchKeyword) {
       return cardsData;
     }
     if (activeBadge?.id === 0) {
@@ -116,7 +112,11 @@ export default function ViewCardPage() {
     <>
       <S.ViewCardPage>
         <Header color='blue' />
-        <SearchBar theme='white' setSearchData={setSearchData} />
+        <SearchBar
+          theme='white'
+          setSearchData={setSearchData}
+          myCardId={myCardId}
+        />
 
         <S.ButtonContainer>
           <S.GroupBadgeWrapper>

--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -89,7 +89,7 @@ export default function ViewCardPage() {
     }
   };
 
-  const searchKeyword = localStorage.getItem('searchKeyword') || '';
+  const searchKeyword = localStorage.getItem('searchKeyword');
 
   const getDisplayData = () => {
     if (searchKeyword && activeBadge?.id !== 0) {

--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { getCards, getCardsByGroup, getGroupList, getMyCard } from '../../apis';
 import { BlueBadge, CardInfo, Header, SearchBar } from '../../components';
 import Icon from '../../components/Icon/Icon';
@@ -63,6 +64,7 @@ export default function ViewCardPage() {
       : cardsData.filter((data) => data.categoryName === activeBadge);
 
   filteredData = filteredData.sort((a, b) => a.name.localeCompare(b.name));
+
   useEffect(() => {
     fetchCards();
   }, [myCardId, activeBadge]);
@@ -92,7 +94,23 @@ export default function ViewCardPage() {
 
   const searchParams = new URLSearchParams(location.search);
   const keyword = searchParams.get('keyword');
-  const displayData = keyword ? searchData : cardsData;
+
+  const getDisplayData = () => {
+    if (keyword && activeBadge?.id !== 0) {
+      return cardsData.filter((card) =>
+        searchData.some((searchCard) => searchCard.id === card.id)
+      );
+    }
+    if (!keyword) {
+      return cardsData;
+    }
+    if (activeBadge?.id === 0) {
+      return searchData;
+    }
+    return searchData.filter((data) => data.category === activeBadge?.name);
+  };
+
+  const displayData = getDisplayData();
 
   return (
     <>


### PR DESCRIPTION
## 📝 작업 내용
close #149 

- 검색 로직 url param 방식에서 localStorage에서 가져오는 방식으로 수정
- 검색에 디바운싱 적용
- 검색어가 있으면서 그룹 필터를 사용한 경우, 교집합만 나오게 함
- home에서 검색할 경우 명함보기 페이지에서 검색 결과 나오도록
- 홈, 명함보기 페이지에서 내 명함 빼고 보이도록

<br />

## 📸 스크린샷

https://github.com/user-attachments/assets/031cf0b7-0e26-4fae-b438-ce6ff9b77bcf


<br />

## 📌 참고사항
검색 로직 localStorage에서 가져오는 방식으로 수정한 이유
- 저희 서비스 특성상 검색어 결과를 실시간으로 보여주는 게 중요한데, url param 방식을 쓸 경우 매번 url의 param을 바꿔야 합니다. 그것보다는 url은 유지하고, 검색어를 state로 관리하는 게 좋을 것 같다고 생각했습니다. 
<br />
