### PR TITLE
#180 [FIX] 업로드 가능한 이미지는 1장만 되도록 문구 수정

### DIFF
--- a/src/pages/AddCardPage/AddCardPage.style.jsx
+++ b/src/pages/AddCardPage/AddCardPage.style.jsx
@@ -55,7 +55,7 @@ export const AddImageContainer = styled.div`
 export const AddBoxTitle = styled.h3`
   margin: 6px 0 13px;
   color: var(--primary, #2d29ff);
-  font-size: 14px;
+  font-size: 18px;
   font-weight: 500;
   line-height: 150%;
   letter-spacing: -0.7px;
@@ -73,7 +73,7 @@ export const AddBoxSubTitle = styled.p`
   padding: 10px 0 16px;
   color: var(--grey2, #949494);
   text-align: center;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 150%;
   letter-spacing: -0.5px;
 `;
@@ -101,7 +101,7 @@ export const AddBoxDesc = styled.div`
 export const AddBoxText = styled.p`
   color: var(--grey2, #949494);
   text-align: center;
-  font-size: 11px;
+  font-size: 14px;
   line-height: 150%;
   letter-spacing: -0.5px;
 `;
@@ -109,7 +109,7 @@ export const AddBoxText = styled.p`
 export const ImportImageBtnWrapper = styled.div`
   display: flex;
   justify-content: center;
-  padding: 14px;
+  padding: 10px;
 `;
 
 export const PreviewContainer = styled.div`
@@ -126,14 +126,15 @@ export const ImportImageBtn = styled.label`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 4px 10px;
+  padding: 10px 14px;
   gap: 8px;
   border-radius: 10px;
   background: var(--primary, #2d29ff);
   color: var(--white, #fff);
-  font-size: 11px;
+  font-size: 14px;
   line-height: 130%;
   letter-spacing: -0.5px;
+  cursor: pointer;
 `;
 
 // 직접 입력으로 명함 추가

--- a/src/pages/AddCardPage/ImageInputForm.jsx
+++ b/src/pages/AddCardPage/ImageInputForm.jsx
@@ -30,19 +30,11 @@ export default function ImageInputForm({
         <S.AddBoxDescWrapper>
           <S.AddBoxDesc>
             <Icon id='dot' />
-            <S.AddBoxText>
-              선택한 모든 명함 이미지는 앞면으로 인식합니다.
-            </S.AddBoxText>
+            <S.AddBoxText>이미지는 1장만 업로드할 수 있습니다.</S.AddBoxText>
           </S.AddBoxDesc>
           <S.AddBoxDesc>
             <Icon id='dot' />
-            <S.AddBoxText>
-              이미지는 한 번에 2장까지 업로드할 수 있습니다.
-            </S.AddBoxText>
-          </S.AddBoxDesc>
-          <S.AddBoxDesc>
-            <Icon id='dot' />
-            <S.AddBoxText>이미지 한 장 당 최대 크기는 1MB 입니다.</S.AddBoxText>
+            <S.AddBoxText>업로드 가능한 최대 크기는 1MB 입니다.</S.AddBoxText>
           </S.AddBoxDesc>
         </S.AddBoxDescWrapper>
         {selectedImage === null && (

--- a/src/pages/AddCardPage/ImageInputForm.jsx
+++ b/src/pages/AddCardPage/ImageInputForm.jsx
@@ -1,6 +1,11 @@
 import * as S from './AddCardPage.style';
 import Icon from '../../components/Icon/Icon';
 
+const UPLOAD_GUIDELINES = [
+  '이미지는 1장만 업로드할 수 있습니다.',
+  '업로드 가능한 최대 크기는 1MB 입니다.',
+];
+
 export default function ImageInputForm({
   selectedImage,
   onUploadImage,
@@ -28,14 +33,12 @@ export default function ImageInputForm({
           이미지 파일을 여기에 끌어다 놓으세요.
         </S.AddBoxSubTitle>
         <S.AddBoxDescWrapper>
-          <S.AddBoxDesc>
-            <Icon id='dot' />
-            <S.AddBoxText>이미지는 1장만 업로드할 수 있습니다.</S.AddBoxText>
-          </S.AddBoxDesc>
-          <S.AddBoxDesc>
-            <Icon id='dot' />
-            <S.AddBoxText>업로드 가능한 최대 크기는 1MB 입니다.</S.AddBoxText>
-          </S.AddBoxDesc>
+          {UPLOAD_GUIDELINES.map((guideline, index) => (
+            <S.AddBoxDesc key={index}>
+              <Icon id='dot' />
+              <S.AddBoxText>{guideline}</S.AddBoxText>
+            </S.AddBoxDesc>
+          ))}
         </S.AddBoxDescWrapper>
         {selectedImage === null && (
           <S.ImportImageBtnWrapper>


### PR DESCRIPTION
## 📝 작업 내용

- 업로드 가능한 이미지는 1장만 되도록 문구 수정
- 이미지 직접 업로드 페이지 내 폰트 사이즈 수정 (11px >> 14px)

<br />

## ✅ PR 전 체크리스트

- [x] 이번 PR에서 `구현되지 않은 부분`, `예정된 기능 개선` 등은 `참고사항`에 명시했나요?
- [x] PR 완료 후 `충돌(conflict)` 여부를 확인하고, 충돌이 있다면 해결해 주세요.

<br />

## 📸 스크린샷

<img width="250" alt="" src="https://github.com/user-attachments/assets/95d2886d-409e-406f-b7a2-accbb1eef1fe">


<br />

<!--
## 📌 참고사항

<br />
-->
