### PR TITLE
#216 [DESIGN] 명함 사진 사이즈 수정

### DIFF
--- a/src/pages/CardDetailPage/CardDetailPage.style.jsx
+++ b/src/pages/CardDetailPage/CardDetailPage.style.jsx
@@ -204,10 +204,12 @@ export const CardImageContainer = styled.div`
 export const CardImageBox = styled.div`
   overflow: hidden;
   border-radius: 10px;
-
+  width: calc(50% - 10px);
+  aspect-ratio: 9 / 5;
+  max-width: 270px;
   img {
-    width: 100px;
-    height: 100px;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
   }
 `;

--- a/src/pages/DetailEditPage/DetailEditPage.style.jsx
+++ b/src/pages/DetailEditPage/DetailEditPage.style.jsx
@@ -297,10 +297,13 @@ export const CardImageBox = styled.div`
   position: relative;
   overflow: hidden;
   border-radius: 10px;
+  width: calc(50% - 10px);
+  max-width: 270px;
+  aspect-ratio: 9 / 5;
 
   img {
-    width: 100px;
-    height: 100px;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
   }
 `;


### PR DESCRIPTION
## 📝 작업 내용

- 명함 사진 사이즈 수정
- 명함 규격에 맞게 비율 조정
- 사진의 width는 최대 270px로

<br />

## ✅ PR 전 체크리스트

- [x] 이번 PR에서 `구현되지 않은 부분`, `예정된 기능 개선` 등은 `참고사항`에 명시했나요?
- [x] PR 완료 후 `충돌(conflict)` 여부를 확인하고, 충돌이 있다면 해결해 주세요.

<br />

## 📸 스크린샷

<img width="250" alt="" src="https://github.com/user-attachments/assets/f2643862-64eb-4fe3-bcf8-ea90bf25bf53">
<img width="250" alt="" src="https://github.com/user-attachments/assets/0b0b2709-1bd6-44a9-b1a3-bd6b068a1e1a">


<br />

<!--
## 📌 참고사항

<br />
-->
