### PR TITLE
#231 [MODIFY] CardInfo에서 회사 정보도 띄우도록

### DIFF
--- a/src/components/CardInfo/CardInfo.jsx
+++ b/src/components/CardInfo/CardInfo.jsx
@@ -7,6 +7,7 @@ import * as S from './CardInfo.style';
 export default function CardInfo({
   id,
   name,
+  company,
   position,
   department,
   imageUrl,
@@ -31,18 +32,23 @@ export default function CardInfo({
         <S.Info>
           <S.Name isSelected={isSelected}>{name}</S.Name>
           <S.Role isSelected={isSelected}>
-            {department} {department && position ? `/ ${position}` : position}
+            {`${company || ''}${company && (department || position) ? ' / ' : ''}${department || ''}${department && position ? ' / ' : ''}${position || ''}`}
           </S.Role>
         </S.Info>
       </S.CardWrapper>
       {!isDeleteMode && (
         <S.ArrowIconWrapper>
-          <Icon id='arrow-right' fill='none' width={13} height={13}/>
+          <Icon id='arrow-right' fill='none' width={13} height={13} />
         </S.ArrowIconWrapper>
       )}
       {isDeleteMode && (
         <S.ArrowIconWrapper>
-          <Icon id={isSelected ? 'circle-check' : 'circle'} fill='none' width={16} height={16}/>
+          <Icon
+            id={isSelected ? 'circle-check' : 'circle'}
+            fill='none'
+            width={16}
+            height={16}
+          />
         </S.ArrowIconWrapper>
       )}
     </S.Card>

--- a/src/components/MyCard/MyCard.jsx
+++ b/src/components/MyCard/MyCard.jsx
@@ -25,7 +25,7 @@ export default function MyCard({
       <S.ProfileText>
         <S.Name>{name}</S.Name>
         <S.Team>
-          {`${company || ''}${company && (department || position) ? ' | ' : ''}${department || ''}${department && position ? ' | ' : ''}${position || ''}`}
+          {`${company || ''}${company && (department || position) ? ' / ' : ''}${department || ''}${department && position ? ' / ' : ''}${position || ''}`}
         </S.Team>
         {phone && (
           <S.ExtraInfo>

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -97,6 +97,7 @@ export default function HomePage() {
                 <CardInfo
                   id={data.id}
                   name={data.name}
+                  company={data.company}
                   position={data.position}
                   department={data.department}
                   imageUrl={data.profImgUrl}

--- a/src/pages/ViewCardPage/ViewCardPage.jsx
+++ b/src/pages/ViewCardPage/ViewCardPage.jsx
@@ -170,9 +170,9 @@ export default function ViewCardPage() {
               id={data.id}
               key={data.id}
               name={data.name}
+              company={data.company}
               position={data.position}
               department={data.department}
-              company={data.company}
               imageUrl={data.profImgUrl}
               isDeleteMode={isDeleteMode}
               isSelected={selectedCards.includes(data.id)}


### PR DESCRIPTION
## 📝 작업 내용
- 현재 CardInfo에는 `부서 / 직책`만 띄우고 있는데 이 경우 어떤 명함인지 파악이 쉽지 않아 `회사 / 부서 / 직책`로 수정

<img width="744" alt="image" src="https://github.com/user-attachments/assets/631f8101-d545-4776-b7cf-48da2084eb04" />

